### PR TITLE
order's 'DELIVERY_ID' save fix for letters in code

### DIFF
--- a/src/Executors/SaleOrderRest.php
+++ b/src/Executors/SaleOrderRest.php
@@ -183,6 +183,14 @@ class SaleOrderRest implements IExecutor {
 			$overrides
 		);
 
+		// XXX Bitrix\Sale\Compatible\OrderCompatibility
+		// fillShipmentCollectionFromRequest(){
+		// $deliveryCode = < ... > $fields['DELIVERY_ID']
+		// $deliveryId = \CSaleDelivery::getIdByCode($deliveryCode);
+		$fields[ 'DELIVERY_ID' ] = \CSaleDelivery::getCodeById(
+			$fields[ 'DELIVERY_ID' ]
+		);
+
 		// Create order
 		$orderId = $order->Add($fields);
 


### PR DESCRIPTION
on creation of order, the 'DELIVERY_ID' value save fix for built-in
'rus_post*' types of delivery at least