### PR TITLE
fix(section): uf's iblock's GetList() w/empty IDs

### DIFF
--- a/src/Executors/IblockSectionRest.php
+++ b/src/Executors/IblockSectionRest.php
@@ -141,7 +141,10 @@ class IblockSectionRest implements IExecutor {
 				'FIELD_NAME' => 'UF_FILTER_TAGS',
 			] );
 			$entitiesCount = $sth->SelectedRowsCount();
-			if( 1 == $entitiesCount ){
+			if( ( ! empty( $uf_ft_ids ) )
+					&&
+					( 1 == $entitiesCount )
+				){
 				$userFieldArr = $sth->fetch();
 				if( ( ! empty( $userFieldArr ) )
 					&&

--- a/src/Executors/IblockSectionRest.php
+++ b/src/Executors/IblockSectionRest.php
@@ -130,7 +130,10 @@ class IblockSectionRest implements IExecutor {
 			$results[0] = $result;
 		}
 
-		if( is_array( $results[0][ 'UF_FILTER_TAGS' ] ) ){
+		if( is_array( $results[0][ 'UF_FILTER_TAGS' ] )
+				&&
+			( ! empty( $results[0][ 'UF_FILTER_TAGS' ] ) )
+		){
 			$uf_ft_ids = $results[0][ 'UF_FILTER_TAGS' ];
 
 
@@ -141,10 +144,7 @@ class IblockSectionRest implements IExecutor {
 				'FIELD_NAME' => 'UF_FILTER_TAGS',
 			] );
 			$entitiesCount = $sth->SelectedRowsCount();
-			if( ( ! empty( $uf_ft_ids ) )
-					&&
-					( 1 == $entitiesCount )
-				){
+			if( 1 == $entitiesCount ){
 				$userFieldArr = $sth->fetch();
 				if( ( ! empty( $userFieldArr ) )
 					&&


### PR DESCRIPTION
user fields' iblock being GetList()ed with empty array as filter for
'ID' field returns every element